### PR TITLE
💄Make button with hover effects but no animation

### DIFF
--- a/src/components/standard-button/standard-button.component.jsx
+++ b/src/components/standard-button/standard-button.component.jsx
@@ -5,7 +5,7 @@ import './standard-button.styles.scss';
 const StandardButton = (props) => (
 
     <div>
-        <div className="wrapper">
+        <div style={{ height: props.height, width: props.width }} className="wrapper">
             <div className="cta">
                 <span>{props.children}</span>
             </div>

--- a/src/components/standard-button/standard-button.component.jsx
+++ b/src/components/standard-button/standard-button.component.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import './standard-button.styles.scss';
+
+const StandardButton = (props) => (
+
+    <div>
+        <div className="wrapper">
+            <div className="cta">
+                <span>{props.children}</span>
+            </div>
+        </div>
+    </div>
+
+);
+
+export default StandardButton;

--- a/src/components/standard-button/standard-button.styles.scss
+++ b/src/components/standard-button/standard-button.styles.scss
@@ -5,6 +5,7 @@
   .wrapper {
     display: flex;
     justify-content: center;
+    position: relative;
   }
   
   .cta {

--- a/src/components/standard-button/standard-button.styles.scss
+++ b/src/components/standard-button/standard-button.styles.scss
@@ -1,0 +1,41 @@
+* {
+    box-sizing: border-box;
+  }
+  
+  .wrapper {
+    display: flex;
+    justify-content: center;
+  }
+  
+  .cta {
+      display: block;
+      text-decoration: none;
+      font: YuGothic;
+      font-size: 16px;
+      text-transform: uppercase;
+      color: #5A4537;
+      background: white;
+      transition: 0.5s;
+      width: 100%;
+      height: 100%;
+      position: absolute;
+      display: flex; 
+      justify-content: center;
+      align-items: center;
+  }
+  
+  .cta:focus {
+     outline: none; 
+  }
+  
+  .cta:hover {
+      background-color: #FBC638;
+      color: white;
+  }
+
+  
+
+  
+
+
+  


### PR DESCRIPTION
**What did you do?**
- Made a standard button, it has hover effects, no animation, and fills to size of parent container

**Screenshot**
![8  StandardButton - reg](https://user-images.githubusercontent.com/59023409/132647418-1be97718-5c6f-45ec-bd43-163d460adf5f.png)
![8  StandardButton - hover](https://user-images.githubusercontent.com/59023409/132647448-92f19788-ab39-45a1-8094-8c8dcf0b23f5.png)


**How to Check Feature/Bug Fix**
```
import './App.css';
import StandardButton from './components/standard-button/standard-button.component';

function App() {
  return (
    <div className="container">
      <div className='background'>

        <StandardButton width="300px" height="50px">商品ページへ</StandardButton>

      </div>
    </div>
  );
}

export default App;
```

**Link to the Design**
(https://xd.adobe.com/view/c0f0ee74-781d-434f-9960-3ff85a002849-95a3/specs/?fbclid=IwAR3bcz-BSXJGrgTXDSVBv0y-PYnSKaPM075W3UEhqyWRb_iHMHv7nu77Hq4)
