### PR TITLE
💄Standard button

### DIFF
--- a/src/components/standard-button/standard-button.component.jsx
+++ b/src/components/standard-button/standard-button.component.jsx
@@ -4,13 +4,11 @@ import './standard-button.styles.scss';
 
 const StandardButton = (props) => (
 
-    <div>
-        <div style={{ height: props.height, width: props.width }} className="wrapper">
-            <div className="cta">
-                <span>{props.children}</span>
-            </div>
+    <a href={props.url} style={{ height: props.height, width: props.width }} className="wrapper">
+        <div className="cta">
+            <p>{props.children}</p>
         </div>
-    </div>
+    </a>
 
 );
 

--- a/src/components/standard-button/standard-button.styles.scss
+++ b/src/components/standard-button/standard-button.styles.scss
@@ -16,7 +16,7 @@
       text-transform: uppercase;
       color: #5A4537;
       background: white;
-      transition: 0.5s;
+      transition: 0.3s;
       width: 100%;
       height: 100%;
       position: absolute;
@@ -26,17 +26,15 @@
   }
   
   .cta:focus {
-     outline: none; 
+     outline: none;
   }
   
   .cta:hover {
-      background-color: #FBC638;
+      background-color: #CCB84B;
       color: white;
+      cursor: pointer;
   }
 
-  
-
-  
-
-
-  
+  .cta:active {
+    background-color: #a3943d;
+  }


### PR DESCRIPTION
**What did you do?**
- changed the button to the correct colour
- added a pressed state - with a darker colour
- added a link to the button

**Screenshot**
![8  StandardButton 2 - reg](https://user-images.githubusercontent.com/59023409/138545720-66f49b02-73d1-4abf-a6e0-3557a69d1a0b.png)
![8  StandardButton 2 - pressed](https://user-images.githubusercontent.com/59023409/138545722-94fcb2eb-3ce6-417e-97af-350adedd4620.png)

**How to Check Feature/Bug Fix**
```
import StandardButton from './components/standard-button/standard-button.component';

function App() {
  return (
    <StandardButton width="300px" height="50px" url="https://en.wikipedia.org/wiki/Coconut">
      商品ページへ
    </StandardButton>
  );
}

export default App;
```

**Link to the Design**
(https://xd.adobe.com/view/c0f0ee74-781d-434f-9960-3ff85a002849-95a3/specs/?fbclid=IwAR3bcz-BSXJGrgTXDSVBv0y-PYnSKaPM075W3UEhqyWRb_iHMHv7nu77Hq4)
